### PR TITLE
Fix next salary date for day before last working day

### DIFF
--- a/src/ConsoleApp/Services/PaymentDateCalculator.cs
+++ b/src/ConsoleApp/Services/PaymentDateCalculator.cs
@@ -64,7 +64,19 @@ namespace ConsoleApp.Services
 
         private DateTime GetDayBeforeLastWorkingDay()
         {
-            return GetWorkingDayOfMonth(_currentDateTime.Year, _currentDateTime.Month).AsEnumerable().Reverse().Skip(1).First();
+            var workingDays = GetWorkingDayOfMonth(_currentDateTime.Year, _currentDateTime.Month).ToList();
+            var dayBeforeLast = workingDays[^2];
+
+            if (_currentDateTime.Date >= dayBeforeLast.Date)
+            {
+                int nextYear = _currentDateTime.Month == 12 ? _currentDateTime.Year + 1 : _currentDateTime.Year;
+                int nextMonth = _currentDateTime.Month == 12 ? 1 : _currentDateTime.Month + 1;
+
+                workingDays = GetWorkingDayOfMonth(nextYear, nextMonth).ToList();
+                dayBeforeLast = workingDays[^2];
+            }
+
+            return dayBeforeLast;
         }
 
         private DateTime GetFirstXDay(int day)

--- a/tests/ConsoleApp.UnitTests/Helpers/TestData.cs
+++ b/tests/ConsoleApp.UnitTests/Helpers/TestData.cs
@@ -38,7 +38,7 @@ namespace ConsoleApp.UnitTests.Helpers
         {
             new object[] {new DateTime(2017, 6, 8), GetHolidays(), Enums.SalaryFrequency.DayBeforeLastWorkingDay, 0, new DateTime(2017, 6, 29)},
             new object[] {new DateTime(2017, 9, 20), GetHolidays(), Enums.SalaryFrequency.DayBeforeLastWorkingDay, 0, new DateTime(2017, 9, 27)},
-            new object[] {new DateTime(2020, 12, 31), GetHolidays(), Enums.SalaryFrequency.DayBeforeLastWorkingDay, 0, new DateTime(2020, 12, 30)}
+            new object[] {new DateTime(2020, 12, 31), GetHolidays(), Enums.SalaryFrequency.DayBeforeLastWorkingDay, 0, new DateTime(2021, 1, 28)}
         };
 
         public static readonly object[][] LastWorkingDayOfMonthData =


### PR DESCRIPTION
## Summary
- correct logic for day-before-last working day calculation
- update unit test expectations

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841ecaf7c3c83319c4930c879d25034